### PR TITLE
Publishable announcements

### DIFF
--- a/client/src/main/java/org/dreamexposure/discal/client/message/AnnouncementMessageFormatter.java
+++ b/client/src/main/java/org/dreamexposure/discal/client/message/AnnouncementMessageFormatter.java
@@ -1,6 +1,27 @@
 package org.dreamexposure.discal.client.message;
 
 import com.google.api.services.calendar.model.Event;
+
+import org.dreamexposure.discal.client.DisCalClient;
+import org.dreamexposure.discal.core.database.DatabaseManager;
+import org.dreamexposure.discal.core.enums.announcement.AnnouncementType;
+import org.dreamexposure.discal.core.enums.event.EventColor;
+import org.dreamexposure.discal.core.object.GuildSettings;
+import org.dreamexposure.discal.core.object.announcement.Announcement;
+import org.dreamexposure.discal.core.object.calendar.CalendarData;
+import org.dreamexposure.discal.core.object.event.EventData;
+import org.dreamexposure.discal.core.utils.ChannelUtils;
+import org.dreamexposure.discal.core.utils.GlobalConst;
+import org.dreamexposure.discal.core.utils.ImageUtils;
+import org.dreamexposure.discal.core.utils.RoleUtils;
+import org.dreamexposure.discal.core.utils.UserUtils;
+import org.dreamexposure.discal.core.wrapper.google.CalendarWrapper;
+import org.dreamexposure.discal.core.wrapper.google.EventWrapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
 import discord4j.common.util.Snowflake;
 import discord4j.core.object.entity.Guild;
 import discord4j.core.object.entity.Member;
@@ -11,24 +32,9 @@ import discord4j.core.spec.EmbedCreateSpec;
 import discord4j.rest.http.client.ClientException;
 import discord4j.rest.util.Image;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.dreamexposure.discal.client.DisCalClient;
-import org.dreamexposure.discal.core.database.DatabaseManager;
-import org.dreamexposure.discal.core.enums.announcement.AnnouncementType;
-import org.dreamexposure.discal.core.enums.event.EventColor;
-import org.dreamexposure.discal.core.object.GuildSettings;
-import org.dreamexposure.discal.core.object.announcement.Announcement;
-import org.dreamexposure.discal.core.object.calendar.CalendarData;
-import org.dreamexposure.discal.core.object.event.EventData;
-import org.dreamexposure.discal.core.utils.*;
-import org.dreamexposure.discal.core.wrapper.google.CalendarWrapper;
-import org.dreamexposure.discal.core.wrapper.google.EventWrapper;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.function.TupleUtils;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * Created by Nova Fox on 3/4/2017.
@@ -37,19 +43,19 @@ import java.util.function.Consumer;
  */
 @SuppressWarnings({"Duplicates", "MagicNumber", "StringConcatenationMissingWhitespace"})
 public class AnnouncementMessageFormatter {
-    public static Mono<Consumer<EmbedCreateSpec>> getFormatAnnouncementEmbed(final Announcement a, final GuildSettings settings) {
-        final Mono<Guild> guild = DisCalClient.getClient().getGuildById(settings.getGuildID()).cache();
+    public static Mono<Consumer<EmbedCreateSpec>> getFormatAnnouncementEmbed(Announcement a, GuildSettings settings) {
+        Mono<Guild> guild = DisCalClient.getClient().getGuildById(settings.getGuildID()).cache();
 
-        final Mono<String> channelName = guild
+        Mono<String> channelName = guild
             .flatMap(g -> ChannelUtils.getChannelNameFromNameOrId(a.getAnnouncementChannelId(), g));
 
-        final Mono<EventData> eData = Mono.just(a)
+        Mono<EventData> eData = Mono.just(a)
             .map(Announcement::getAnnouncementType)
             .filter(t -> t.equals(AnnouncementType.SPECIFIC) || t.equals(AnnouncementType.RECUR))
             .flatMap(t -> DatabaseManager.getEventData(a.getGuildId(), a.getEventId()))
             .defaultIfEmpty(EventData.empty()).cache();
 
-        final Mono<Boolean> img = eData.filter(EventData::shouldBeSaved)
+        Mono<Boolean> img = eData.filter(EventData::shouldBeSaved)
             .flatMap(ed -> ImageUtils.validate(ed.getImageLink(), settings.isPatronGuild()))
             .defaultIfEmpty(false);
 
@@ -95,23 +101,23 @@ public class AnnouncementMessageFormatter {
     }
 
     @Deprecated
-    public static Mono<Consumer<EmbedCreateSpec>> getCondensedAnnouncementEmbed(final Announcement a, final GuildSettings settings) {
-        final Mono<Guild> guild = DisCalClient.getClient().getGuildById(settings.getGuildID());
+    public static Mono<Consumer<EmbedCreateSpec>> getCondensedAnnouncementEmbed(Announcement a, GuildSettings settings) {
+        Mono<Guild> guild = DisCalClient.getClient().getGuildById(settings.getGuildID());
 
-        final Mono<Event> event = Mono.just(a)
+        Mono<Event> event = Mono.just(a)
             .map(Announcement::getAnnouncementType)
             .filter(t -> t.equals(AnnouncementType.SPECIFIC))
             .flatMap(t -> DatabaseManager.getMainCalendar(a.getGuildId()))
             .flatMap(cd -> EventWrapper.getEvent(cd, settings, a.getEventId()))
             .defaultIfEmpty(new Event());
 
-        final Mono<EventData> eData = Mono.just(a)
+        Mono<EventData> eData = Mono.just(a)
             .map(Announcement::getAnnouncementType)
             .filter(t -> t.equals(AnnouncementType.SPECIFIC) || t.equals(AnnouncementType.RECUR))
             .flatMap(t -> DatabaseManager.getEventData(a.getGuildId(), a.getEventId()))
             .defaultIfEmpty(EventData.empty()).cache();
 
-        final Mono<Boolean> img = eData.filter(EventData::shouldBeSaved)
+        Mono<Boolean> img = eData.filter(EventData::shouldBeSaved)
             .flatMap(ed -> ImageUtils.validate(ed.getImageLink(), settings.isPatronGuild()))
             .defaultIfEmpty(false);
 
@@ -158,24 +164,24 @@ public class AnnouncementMessageFormatter {
             }));
     }
 
-    public static Mono<Consumer<EmbedCreateSpec>> getCondensedAnnouncementEmbed(final Announcement a, final int calNum,
-                                                                                final GuildSettings settings) {
-        final Mono<Guild> guild = DisCalClient.getClient().getGuildById(settings.getGuildID());
+    public static Mono<Consumer<EmbedCreateSpec>> getCondensedAnnouncementEmbed(Announcement a, int calNum,
+                                                                                GuildSettings settings) {
+        Mono<Guild> guild = DisCalClient.getClient().getGuildById(settings.getGuildID());
 
-        final Mono<Event> event = Mono.just(a)
+        Mono<Event> event = Mono.just(a)
             .map(Announcement::getAnnouncementType)
             .filter(t -> t.equals(AnnouncementType.SPECIFIC))
             .flatMap(t -> DatabaseManager.getCalendar(a.getGuildId(), calNum))
             .flatMap(cd -> EventWrapper.getEvent(cd, settings, a.getEventId()))
             .defaultIfEmpty(new Event());
 
-        final Mono<EventData> eData = Mono.just(a)
+        Mono<EventData> eData = Mono.just(a)
             .map(Announcement::getAnnouncementType)
             .filter(t -> t.equals(AnnouncementType.SPECIFIC) || t.equals(AnnouncementType.RECUR))
             .flatMap(t -> DatabaseManager.getEventData(a.getGuildId(), a.getEventId()))
             .defaultIfEmpty(EventData.empty()).cache();
 
-        final Mono<Boolean> img = eData.filter(EventData::shouldBeSaved)
+        Mono<Boolean> img = eData.filter(EventData::shouldBeSaved)
             .flatMap(ed -> ImageUtils.validate(ed.getImageLink(), settings.isPatronGuild()))
             .defaultIfEmpty(false);
 
@@ -222,25 +228,25 @@ public class AnnouncementMessageFormatter {
             }));
     }
 
-    private static Mono<Consumer<EmbedCreateSpec>> getRealAnnouncementEmbed(final Announcement a, final Event event, final CalendarData cd,
-                                                                            final GuildSettings settings) {
-        final Mono<Guild> guild = DisCalClient.getClient().getGuildById(settings.getGuildID());
+    private static Mono<Consumer<EmbedCreateSpec>> getRealAnnouncementEmbed(Announcement a, Event event, CalendarData cd,
+                                                                            GuildSettings settings) {
+        Mono<Guild> guild = DisCalClient.getClient().getGuildById(settings.getGuildID());
 
-        final Mono<String> startDate = EventMessageFormatter
+        Mono<String> startDate = EventMessageFormatter
             .getHumanReadableDate(event.getStart(), cd.getCalendarNumber(), false, settings);
 
-        final Mono<String> startTime = EventMessageFormatter
+        Mono<String> startTime = EventMessageFormatter
             .getHumanReadableTime(event.getStart(), cd.getCalendarNumber(), false, settings);
 
-        final Mono<String> timezone = CalendarWrapper.getCalendar(cd, settings)
+        Mono<String> timezone = CalendarWrapper.getCalendar(cd, settings)
             .map(com.google.api.services.calendar.model.Calendar::getTimeZone)
             .defaultIfEmpty("TZ Unknown/Error");
 
-        final Mono<EventData> eData = DatabaseManager.getEventData(settings.getGuildID(), event.getId())
+        Mono<EventData> eData = DatabaseManager.getEventData(settings.getGuildID(), event.getId())
             .defaultIfEmpty(EventData.empty())
             .cache();
 
-        final Mono<Boolean> img = eData.filter(EventData::shouldBeSaved)
+        Mono<Boolean> img = eData.filter(EventData::shouldBeSaved)
             .flatMap(ed -> ImageUtils.validate(ed.getImageLink(), settings.isPatronGuild()))
             .defaultIfEmpty(false);
 
@@ -258,9 +264,9 @@ public class AnnouncementMessageFormatter {
                 spec.setUrl(event.getHtmlLink());
 
                 try {
-                    final EventColor ec = EventColor.fromNameOrHexOrID(event.getColorId());
+                    EventColor ec = EventColor.fromNameOrHexOrID(event.getColorId());
                     spec.setColor(ec.asColor());
-                } catch (final Exception e) {
+                } catch (Exception e) {
                     //I dunno, color probably null.
                     spec.setColor(GlobalConst.discalColor);
                 }
@@ -295,13 +301,13 @@ public class AnnouncementMessageFormatter {
                         spec.addField(Messages.getMessage("Embed.Announcement.Announce.Time", settings), sTime, true);
                         spec.addField(Messages.getMessage("Embed.Announcement.Announce.TimeZone", settings), tz, true);
                     } else {
-                        final String start = sDate + " at " + sTime + " " + tz;
+                        String start = sDate + " at " + sTime + " " + tz;
                         spec.addField(Messages.getMessage("Embed.Announcement.Announce.Start", settings), start, false);
                     }
 
                     if (event.getLocation() != null && !"".equalsIgnoreCase(event.getLocation())) {
                         if (event.getLocation().length() > 300) {
-                            final String location = event.getLocation().substring(0, 300).trim() + "... (cont. on Google Cal)";
+                            String location = event.getLocation().substring(0, 300).trim() + "... (cont. on Google Cal)";
                             spec.addField(Messages.getMessage("Embed.Event.Confirm.Location", settings), location, true);
                         } else {
                             spec.addField(Messages.getMessage("Embed.Event.Confirm.Location", settings), event.getLocation(), true);
@@ -317,12 +323,12 @@ public class AnnouncementMessageFormatter {
     }
 
     @Deprecated
-    public static Mono<Void> sendAnnouncementMessage(final Announcement a, final Event event, final CalendarData data,
-                                                     final GuildSettings settings) {
-        final Mono<Guild> guild = DisCalClient.getClient().getGuildById(settings.getGuildID()).cache();
+    public static Mono<Void> sendAnnouncementMessage(Announcement a, Event event, CalendarData data,
+                                                     GuildSettings settings) {
+        Mono<Guild> guild = DisCalClient.getClient().getGuildById(settings.getGuildID()).cache();
 
-        final Mono<Consumer<EmbedCreateSpec>> embed = getRealAnnouncementEmbed(a, event, data, settings);
-        final Mono<String> mentions = guild.flatMap(g -> getSubscriberMentions(a, g));
+        Mono<Consumer<EmbedCreateSpec>> embed = getRealAnnouncementEmbed(a, event, data, settings);
+        Mono<String> mentions = guild.flatMap(g -> getSubscriberMentions(a, g));
 
         return Mono.zip(guild, embed, mentions)
             .flatMap(TupleUtils.function((g, em, men) ->
@@ -337,10 +343,10 @@ public class AnnouncementMessageFormatter {
             )).then();
     }
 
-    public static Mono<Void> sendAnnouncementMessage(final Guild guild, final Announcement a, final Event event, final CalendarData data,
-                                                     final GuildSettings settings) {
-        final Mono<Consumer<EmbedCreateSpec>> embed = getRealAnnouncementEmbed(a, event, data, settings);
-        final Mono<String> mentions = getSubscriberMentions(a, guild);
+    public static Mono<Void> sendAnnouncementMessage(Guild guild, Announcement a, Event event, CalendarData data,
+                                                     GuildSettings settings) {
+        Mono<Consumer<EmbedCreateSpec>> embed = getRealAnnouncementEmbed(a, event, data, settings);
+        Mono<String> mentions = getSubscriberMentions(a, guild);
 
         return Mono.zip(embed, mentions)
             .flatMap(TupleUtils.function((em, men) ->
@@ -355,8 +361,8 @@ public class AnnouncementMessageFormatter {
             )).then();
     }
 
-    public static Mono<Void> sendAnnouncementDM(final Announcement a, final Event event, final User user, final CalendarData data,
-                                                final GuildSettings settings) {
+    public static Mono<Void> sendAnnouncementDM(Announcement a, Event event, User user, CalendarData data,
+                                                GuildSettings settings) {
         return DisCalClient.getClient().getGuildById(settings.getGuildID())
             .map(g -> Messages.getMessage("Embed.Announcement.Announce.Dm.Message", "%guild%", g.getName(), settings))
             .flatMap(msg -> getRealAnnouncementEmbed(a, event, data, settings)
@@ -364,20 +370,20 @@ public class AnnouncementMessageFormatter {
             ).then();
     }
 
-    private static String condensedTime(final Announcement a) {
+    private static String condensedTime(Announcement a) {
         return a.getHoursBefore() + "H" + a.getMinutesBefore() + "m";
     }
 
-    public static Mono<String> getSubscriberNames(final Announcement a, final Guild guild) {
+    public static Mono<String> getSubscriberNames(Announcement a, Guild guild) {
         return Mono.defer(() -> {
-            final Mono<List<String>> userMentions = Flux.fromIterable(a.getSubscriberUserIds())
+            Mono<List<String>> userMentions = Flux.fromIterable(a.getSubscriberUserIds())
                 .flatMap(s -> UserUtils.getUserFromID(s, guild))
                 .map(Member::getDisplayName)
                 .onErrorReturn("")
                 .collectList()
                 .defaultIfEmpty(new ArrayList<>());
 
-            final Mono<List<String>> roleMentions = Flux.fromIterable(a.getSubscriberRoleIds())
+            Mono<List<String>> roleMentions = Flux.fromIterable(a.getSubscriberRoleIds())
                 .flatMap(s -> {
                     if ("everyone".equalsIgnoreCase(s))
                         return Mono.just("everyone");
@@ -392,15 +398,15 @@ public class AnnouncementMessageFormatter {
                 .defaultIfEmpty(new ArrayList<>());
 
             return Mono.zip(userMentions, roleMentions).map(TupleUtils.function((users, roles) -> {
-                final StringBuilder mentions = new StringBuilder();
+                StringBuilder mentions = new StringBuilder();
 
                 mentions.append("Subscribers: ");
 
-                for (final String s : users) {
+                for (String s : users) {
                     mentions.append(s).append(" ");
                 }
 
-                for (final String s : roles) {
+                for (String s : roles) {
                     mentions.append(s).append(" ");
                 }
 
@@ -409,16 +415,16 @@ public class AnnouncementMessageFormatter {
         });
     }
 
-    private static Mono<String> getSubscriberMentions(final Announcement a, final Guild guild) {
+    private static Mono<String> getSubscriberMentions(Announcement a, Guild guild) {
         return Mono.defer(() -> {
-            final Mono<List<String>> userMentions = Flux.fromIterable(a.getSubscriberUserIds())
+            Mono<List<String>> userMentions = Flux.fromIterable(a.getSubscriberUserIds())
                 .flatMap(s -> UserUtils.getUserFromID(s, guild))
                 .map(Member::getNicknameMention)
                 .onErrorReturn("")
                 .collectList()
                 .defaultIfEmpty(new ArrayList<>());
 
-            final Mono<List<String>> roleMentions = Flux.fromIterable(a.getSubscriberRoleIds())
+            Mono<List<String>> roleMentions = Flux.fromIterable(a.getSubscriberRoleIds())
                 .flatMap(s -> {
                     if ("everyone".equalsIgnoreCase(s))
                         return Mono.just("@everyone");
@@ -433,15 +439,15 @@ public class AnnouncementMessageFormatter {
                 .defaultIfEmpty(new ArrayList<>());
 
             return Mono.zip(userMentions, roleMentions).map(TupleUtils.function((users, roles) -> {
-                final StringBuilder mentions = new StringBuilder();
+                StringBuilder mentions = new StringBuilder();
 
                 mentions.append("Subscribers: ");
 
-                for (final String s : users) {
+                for (String s : users) {
                     mentions.append(s).append(" ");
                 }
 
-                for (final String s : roles) {
+                for (String s : roles) {
                     mentions.append(s).append(" ");
                 }
 

--- a/client/src/main/java/org/dreamexposure/discal/client/message/AnnouncementMessageFormatter.java
+++ b/client/src/main/java/org/dreamexposure/discal/client/message/AnnouncementMessageFormatter.java
@@ -343,9 +343,11 @@ public class AnnouncementMessageFormatter {
                             .flatMap(ignored -> DatabaseManager.deleteAnnouncement(a.getAnnouncementId().toString()))
                             .then(Mono.empty()))
                     .flatMap(chan -> {
-                        if (a.isPublishable())
-                            return Messages.sendMessage(men, em, chan).flatMap(Message::publish);
-                        else
+                        if (a.isPublishable()) {
+                            return Messages.sendMessage(men, em, chan)
+                                .flatMap(Message::publish)
+                                .onErrorResume(e -> Mono.empty());
+                        } else
                             return Messages.sendMessage(men, em, chan);
                     })
             )).then();
@@ -366,9 +368,11 @@ public class AnnouncementMessageFormatter {
                             .flatMap(ignored -> DatabaseManager.deleteAnnouncement(a.getAnnouncementId().toString()))
                             .then(Mono.empty()))
                     .flatMap(chan -> {
-                        if (a.isPublishable())
-                            return Messages.sendMessage(men, em, chan).flatMap(Message::publish);
-                        else
+                        if (a.isPublishable()) {
+                            return Messages.sendMessage(men, em, chan)
+                                .flatMap(Message::publish)
+                                .onErrorResume(e -> Mono.empty());
+                        } else
                             return Messages.sendMessage(men, em, chan);
                     })
             )).then();

--- a/client/src/main/java/org/dreamexposure/discal/client/message/AnnouncementMessageFormatter.java
+++ b/client/src/main/java/org/dreamexposure/discal/client/message/AnnouncementMessageFormatter.java
@@ -6,8 +6,6 @@ import org.dreamexposure.discal.client.DisCalClient;
 import org.dreamexposure.discal.core.database.DatabaseManager;
 import org.dreamexposure.discal.core.enums.announcement.AnnouncementType;
 import org.dreamexposure.discal.core.enums.event.EventColor;
-import org.dreamexposure.discal.core.logger.LogFeed;
-import org.dreamexposure.discal.core.logger.object.LogObject;
 import org.dreamexposure.discal.core.object.GuildSettings;
 import org.dreamexposure.discal.core.object.announcement.Announcement;
 import org.dreamexposure.discal.core.object.calendar.CalendarData;
@@ -93,8 +91,6 @@ public class AnnouncementMessageFormatter {
                 spec.addField(Messages.getMessage("Embed.Announcement.Info.Hours", settings), String.valueOf(a.getHoursBefore()), true);
                 spec.addField(Messages.getMessage("Embed.Announcement.Info.Minutes", settings), String.valueOf(a.getMinutesBefore()), true);
                 spec.addField(Messages.getMessage("Embed.Announcement.Info.Channel", settings), chanName, true);
-                if (settings.isDevGuild() || settings.isPatronGuild())
-                    spec.addField("Publishable", a.isPublishable() + "", true);
                 spec.addField(Messages.getMessage("Embed.Announcement.Info.Info", settings), a.getInfo(), false);
                 if (a.getAnnouncementType().equals(AnnouncementType.COLOR))
                     spec.setColor(a.getEventColor().asColor());
@@ -102,6 +98,8 @@ public class AnnouncementMessageFormatter {
                     spec.setColor(GlobalConst.discalColor);
 
                 spec.addField(Messages.getMessage("Embed.Announcement.Info.Enabled", settings), a.isEnabled() + "", true);
+                if (settings.isDevGuild() || settings.isPatronGuild())
+                    spec.addField("Publishable", a.isPublishable() + "", true);
             }));
     }
 
@@ -345,14 +343,10 @@ public class AnnouncementMessageFormatter {
                             .flatMap(ignored -> DatabaseManager.deleteAnnouncement(a.getAnnouncementId().toString()))
                             .then(Mono.empty()))
                     .flatMap(chan -> {
-                        if (a.isPublishable()) {
-                            return Messages.sendMessage(men, em, chan)
-                                .flatMap(Message::publish)
-                                .doOnError(e -> LogFeed.log(LogObject.forException("Failed to publish ann", e, AnnouncementMessageFormatter.class)))
-                                .onErrorResume(e -> Mono.empty());
-                        } else {
+                        if (a.isPublishable())
+                            return Messages.sendMessage(men, em, chan).flatMap(Message::publish);
+                        else
                             return Messages.sendMessage(men, em, chan);
-                        }
                     })
             )).then();
     }
@@ -372,14 +366,10 @@ public class AnnouncementMessageFormatter {
                             .flatMap(ignored -> DatabaseManager.deleteAnnouncement(a.getAnnouncementId().toString()))
                             .then(Mono.empty()))
                     .flatMap(chan -> {
-                        if (a.isPublishable()) {
-                            return Messages.sendMessage(men, em, chan)
-                                .flatMap(Message::publish)
-                                .doOnError(e -> LogFeed.log(LogObject.forException("Failed to publish ann", e, AnnouncementMessageFormatter.class)))
-                                .onErrorResume(e -> Mono.empty());
-                        } else {
+                        if (a.isPublishable())
+                            return Messages.sendMessage(men, em, chan).flatMap(Message::publish);
+                        else
                             return Messages.sendMessage(men, em, chan);
-                        }
                     })
             )).then();
     }

--- a/client/src/main/java/org/dreamexposure/discal/client/message/Messages.java
+++ b/client/src/main/java/org/dreamexposure/discal/client/message/Messages.java
@@ -1,11 +1,5 @@
 package org.dreamexposure.discal.client.message;
 
-import discord4j.core.event.domain.message.MessageCreateEvent;
-import discord4j.core.object.entity.Message;
-import discord4j.core.object.entity.User;
-import discord4j.core.object.entity.channel.GuildMessageChannel;
-import discord4j.core.spec.EmbedCreateSpec;
-import discord4j.rest.http.client.ClientException;
 import org.dreamexposure.discal.core.file.ReadFile;
 import org.dreamexposure.discal.core.logger.LogFeed;
 import org.dreamexposure.discal.core.logger.object.LogObject;
@@ -13,11 +7,18 @@ import org.dreamexposure.discal.core.object.GuildSettings;
 import org.dreamexposure.discal.core.utils.GlobalConst;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+
+import discord4j.core.event.domain.message.MessageCreateEvent;
+import discord4j.core.object.entity.Message;
+import discord4j.core.object.entity.User;
+import discord4j.core.object.entity.channel.GuildMessageChannel;
+import discord4j.core.spec.EmbedCreateSpec;
+import discord4j.rest.http.client.ClientException;
+import reactor.core.publisher.Mono;
 
 /**
  * @author NovaFox161
@@ -50,8 +51,8 @@ public class Messages {
         return new CopyOnWriteArrayList<String>(langs.keySet());
     }
 
-    public static boolean isSupported(final String _value) {
-        final JSONArray names = langs.names();
+    public static boolean isSupported(String _value) {
+        JSONArray names = langs.names();
         for (int i = 0; i < names.length(); i++) {
             if (_value.equalsIgnoreCase(names.getString(i)))
                 return true;
@@ -59,8 +60,8 @@ public class Messages {
         return false;
     }
 
-    public static String getValidLang(final String _value) {
-        final JSONArray names = langs.names();
+    public static String getValidLang(String _value) {
+        JSONArray names = langs.names();
         for (int i = 0; i < names.length(); i++) {
             if (_value.equalsIgnoreCase(names.getString(i)))
                 return names.getString(i);
@@ -68,8 +69,8 @@ public class Messages {
         return "ENGLISH";
     }
 
-    public static String getMessage(final String key, final GuildSettings settings) {
-        final JSONObject messages;
+    public static String getMessage(String key, GuildSettings settings) {
+        JSONObject messages;
 
         if (settings.getLang() != null && langs.has(settings.getLang()))
             messages = langs.getJSONObject(settings.getLang());
@@ -82,8 +83,8 @@ public class Messages {
             return "***FAILSAFE MESSAGE*** MESSAGE NOT FOUND!! Message requested: " + key;
     }
 
-    public static String getMessage(final String key, final String var, final String replace, final GuildSettings settings) {
-        final JSONObject messages;
+    public static String getMessage(String key, String var, String replace, GuildSettings settings) {
+        JSONObject messages;
 
         if (settings.getLang() != null && langs.has(settings.getLang()))
             messages = langs.getJSONObject(settings.getLang());
@@ -97,92 +98,92 @@ public class Messages {
     }
 
     //Message sending
-    public static Mono<Message> sendMessage(final String message, final MessageCreateEvent event) {
+    public static Mono<Message> sendMessage(String message, MessageCreateEvent event) {
         return event.getMessage().getChannel()
             .flatMap(c -> c.createMessage(spec -> spec.setContent(message)))
             .onErrorResume(ClientException.class, e -> Mono.empty());
     }
 
-    public static Mono<Message> sendMessage(final Consumer<EmbedCreateSpec> embed,
-                                            final MessageCreateEvent event) {
+    public static Mono<Message> sendMessage(Consumer<EmbedCreateSpec> embed,
+                                            MessageCreateEvent event) {
         return event.getMessage().getChannel()
             .flatMap(c -> c.createMessage(spec -> spec.setEmbed(embed)))
             .onErrorResume(ClientException.class, e -> Mono.empty());
     }
 
-    public static Mono<Message> sendMessage(final String message, final Consumer<EmbedCreateSpec> embed,
-                                            final MessageCreateEvent event) {
+    public static Mono<Message> sendMessage(String message, Consumer<EmbedCreateSpec> embed,
+                                            MessageCreateEvent event) {
         return event.getMessage().getChannel()
             .flatMap(c -> c.createMessage(spec -> spec.setContent(message).setEmbed(embed)))
             .onErrorResume(ClientException.class, e -> Mono.empty());
     }
 
-    public static Mono<Message> sendMessage(final String message, final GuildMessageChannel channel) {
+    public static Mono<Message> sendMessage(String message, GuildMessageChannel channel) {
         return channel.createMessage(spec -> spec.setContent(message))
             .onErrorResume(ClientException.class, e -> Mono.empty());
     }
 
-    public static Mono<Message> sendMessage(final Consumer<EmbedCreateSpec> embed, final GuildMessageChannel channel) {
+    public static Mono<Message> sendMessage(Consumer<EmbedCreateSpec> embed, GuildMessageChannel channel) {
         return channel.createMessage(spec -> spec.setEmbed(embed))
             .onErrorResume(ClientException.class, e -> Mono.empty());
     }
 
-    public static Mono<Message> sendMessage(final String message, final Consumer<EmbedCreateSpec> embed,
-                                            final GuildMessageChannel channel) {
+    public static Mono<Message> sendMessage(String message, Consumer<EmbedCreateSpec> embed,
+                                            GuildMessageChannel channel) {
         return channel.createMessage(spec -> spec.setContent(message).setEmbed(embed))
             .onErrorResume(ClientException.class, e -> Mono.empty());
     }
 
     //Direct message sending
-    public static Mono<Message> sendDirectMessage(final String message, final User user) {
+    public static Mono<Message> sendDirectMessage(String message, User user) {
         return user.getPrivateChannel()
             .flatMap(c -> c.createMessage(spec -> spec.setContent(message)))
             .onErrorResume(ClientException.class, e -> Mono.empty());
     }
 
-    public static Mono<Message> sendDirectMessage(final Consumer<EmbedCreateSpec> embed, final User user) {
+    public static Mono<Message> sendDirectMessage(Consumer<EmbedCreateSpec> embed, User user) {
         return user.getPrivateChannel()
             .flatMap(c -> c.createMessage(spec -> spec.setEmbed(embed)))
             .onErrorResume(ClientException.class, e -> Mono.empty());
     }
 
-    public static Mono<Message> sendDirectMessage(final String message, final Consumer<EmbedCreateSpec> embed,
-                                                  final User user) {
+    public static Mono<Message> sendDirectMessage(String message, Consumer<EmbedCreateSpec> embed,
+                                                  User user) {
         return user.getPrivateChannel()
             .flatMap(c -> c.createMessage(spec -> spec.setContent(message).setEmbed(embed)))
             .onErrorResume(ClientException.class, e -> Mono.empty());
     }
 
     //Message editing
-    public static Mono<Message> editMessage(final String message, final Message original) {
+    public static Mono<Message> editMessage(String message, Message original) {
         return original
             .edit(spec -> spec.setContent(message));
     }
 
-    public static Mono<Message> editMessage(final String message, final Consumer<EmbedCreateSpec> embed,
-                                            final Message original) {
+    public static Mono<Message> editMessage(String message, Consumer<EmbedCreateSpec> embed,
+                                            Message original) {
         return original
             .edit(spec -> spec.setContent(message).setEmbed(embed));
     }
 
-    public static Mono<Message> editMessage(final String message, final MessageCreateEvent event) {
+    public static Mono<Message> editMessage(String message, MessageCreateEvent event) {
         return event.getMessage()
             .edit(spec -> spec.setContent(message));
     }
 
-    public static Mono<Message> editMessage(final String message, final Consumer<EmbedCreateSpec> embed,
-                                            final MessageCreateEvent event) {
+    public static Mono<Message> editMessage(String message, Consumer<EmbedCreateSpec> embed,
+                                            MessageCreateEvent event) {
         return event.getMessage()
             .edit(spec -> spec.setContent(message).setEmbed(embed));
     }
 
     //Message deleting
-    public static Mono<Void> deleteMessage(final Message message) {
+    public static Mono<Void> deleteMessage(Message message) {
         return Mono.justOrEmpty(message).flatMap(Message::delete)
             .onErrorResume(e -> Mono.empty());
     }
 
-    public static Mono<Void> deleteMessage(final MessageCreateEvent event) {
+    public static Mono<Void> deleteMessage(MessageCreateEvent event) {
         return deleteMessage(event.getMessage());
     }
 }

--- a/client/src/main/java/org/dreamexposure/discal/client/module/command/AnnouncementCommand.java
+++ b/client/src/main/java/org/dreamexposure/discal/client/module/command/AnnouncementCommand.java
@@ -1,5 +1,10 @@
 package org.dreamexposure.discal.client.module.command;
 
+import discord4j.core.event.domain.message.MessageCreateEvent;
+import discord4j.core.object.entity.Member;
+import discord4j.core.object.entity.Message;
+import discord4j.core.object.entity.Role;
+import discord4j.core.spec.EmbedCreateSpec;
 import org.dreamexposure.discal.client.announcement.AnnouncementCreator;
 import org.dreamexposure.discal.client.message.AnnouncementMessageFormatter;
 import org.dreamexposure.discal.client.message.Messages;
@@ -9,14 +14,10 @@ import org.dreamexposure.discal.core.enums.event.EventColor;
 import org.dreamexposure.discal.core.object.GuildSettings;
 import org.dreamexposure.discal.core.object.announcement.Announcement;
 import org.dreamexposure.discal.core.object.command.CommandInfo;
-import org.dreamexposure.discal.core.utils.AnnouncementUtils;
-import org.dreamexposure.discal.core.utils.ChannelUtils;
-import org.dreamexposure.discal.core.utils.EventUtils;
-import org.dreamexposure.discal.core.utils.GeneralUtils;
-import org.dreamexposure.discal.core.utils.GlobalConst;
-import org.dreamexposure.discal.core.utils.PermissionChecker;
-import org.dreamexposure.discal.core.utils.RoleUtils;
-import org.dreamexposure.discal.core.utils.UserUtils;
+import org.dreamexposure.discal.core.utils.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.function.TupleUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,15 +25,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-
-import discord4j.core.event.domain.message.MessageCreateEvent;
-import discord4j.core.object.entity.Member;
-import discord4j.core.object.entity.Message;
-import discord4j.core.object.entity.Role;
-import discord4j.core.spec.EmbedCreateSpec;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.function.TupleUtils;
 
 /**
  * Created by Nova Fox on 3/4/2017.
@@ -105,7 +97,8 @@ public class AnnouncementCommand implements Command {
         info.getSubCommands().put("info", "Sets an additional info.");
         info.getSubCommands().put("enable", "Enables or Disables the announcement (alias for `disable`)");
         info.getSubCommands().put("disable", "Enables or Disables the announcement (alias for `enable`)");
-        info.getSubCommands().put("infoOnly", "Allows for setting an announcement to ONLY display the ' extra info'");
+        info.getSubCommands().put("infoOnly", "Allows for setting an announcement to ONLY display the 'extra info'");
+        info.getSubCommands().put("publish", "Allows for the event to be published if posted in a news channel");
 
         return info;
     }
@@ -1299,6 +1292,12 @@ public class AnnouncementCommand implements Command {
                 return Messages.sendMessage(Messages.getMessage("Announcement.InfoOnly.Specify", settings), event);
             }
         }).then();
+    }
+
+    private Mono<Void> modulePublish(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+        //TODO: Add code
+
+        return Mono.empty();
     }
 
     private Mono<Void> moduleChannel(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {

--- a/client/src/main/java/org/dreamexposure/discal/client/module/command/AnnouncementCommand.java
+++ b/client/src/main/java/org/dreamexposure/discal/client/module/command/AnnouncementCommand.java
@@ -1,10 +1,5 @@
 package org.dreamexposure.discal.client.module.command;
 
-import discord4j.core.event.domain.message.MessageCreateEvent;
-import discord4j.core.object.entity.Member;
-import discord4j.core.object.entity.Message;
-import discord4j.core.object.entity.Role;
-import discord4j.core.spec.EmbedCreateSpec;
 import org.dreamexposure.discal.client.announcement.AnnouncementCreator;
 import org.dreamexposure.discal.client.message.AnnouncementMessageFormatter;
 import org.dreamexposure.discal.client.message.Messages;
@@ -14,10 +9,14 @@ import org.dreamexposure.discal.core.enums.event.EventColor;
 import org.dreamexposure.discal.core.object.GuildSettings;
 import org.dreamexposure.discal.core.object.announcement.Announcement;
 import org.dreamexposure.discal.core.object.command.CommandInfo;
-import org.dreamexposure.discal.core.utils.*;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.function.TupleUtils;
+import org.dreamexposure.discal.core.utils.AnnouncementUtils;
+import org.dreamexposure.discal.core.utils.ChannelUtils;
+import org.dreamexposure.discal.core.utils.EventUtils;
+import org.dreamexposure.discal.core.utils.GeneralUtils;
+import org.dreamexposure.discal.core.utils.GlobalConst;
+import org.dreamexposure.discal.core.utils.PermissionChecker;
+import org.dreamexposure.discal.core.utils.RoleUtils;
+import org.dreamexposure.discal.core.utils.UserUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +24,15 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+
+import discord4j.core.event.domain.message.MessageCreateEvent;
+import discord4j.core.object.entity.Member;
+import discord4j.core.object.entity.Message;
+import discord4j.core.object.entity.Role;
+import discord4j.core.spec.EmbedCreateSpec;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.function.TupleUtils;
 
 /**
  * Created by Nova Fox on 3/4/2017.
@@ -52,7 +60,7 @@ public class AnnouncementCommand implements Command {
      */
     @Override
     public ArrayList<String> getAliases() {
-        final ArrayList<String> aliases = new ArrayList<>();
+        ArrayList<String> aliases = new ArrayList<>();
         aliases.add("announcements");
         aliases.add("announce");
         aliases.add("alert");
@@ -69,7 +77,7 @@ public class AnnouncementCommand implements Command {
      */
     @Override
     public CommandInfo getCommandInfo() {
-        final CommandInfo info = new CommandInfo(
+        CommandInfo info = new CommandInfo(
             "announcement",
             "Used for all announcement functions.",
             "!announcement <function> (value(s))"
@@ -110,7 +118,7 @@ public class AnnouncementCommand implements Command {
      * @param event The event received.
      */
     @Override
-    public Mono<Void> issueCommand(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    public Mono<Void> issueCommand(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (args.length < 1) {
                 return Messages.sendMessage(Messages.getMessage("Notification.Args.Few", settings), event);
@@ -205,13 +213,13 @@ public class AnnouncementCommand implements Command {
     }
 
 
-    private Mono<Void> moduleCreate(final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleCreate(MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return Mono.when(deleteUserMessage, deleteCreatorMessage)
                     .then(AnnouncementMessageFormatter.getFormatAnnouncementEmbed(a, settings))
@@ -225,13 +233,13 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleEdit(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleEdit(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return Mono.when(deleteUserMessage, deleteCreatorMessage)
                     .then(AnnouncementMessageFormatter.getFormatAnnouncementEmbed(a, settings))
@@ -259,19 +267,19 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleConfirm(final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleConfirm(MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return Mono.when(deleteUserMessage, deleteCreatorMessage)
                     .then(AnnouncementCreator.getCreator().confirmAnnouncement(settings.getGuildID()))
                     .flatMap(acr -> {
                         if (acr.isSuccessful()) {
-                            final String msg;
+                            String msg;
                             if (a.isEditing())
                                 msg = Messages.getMessage("Creator.Announcement.Confirm.Edit.Success", settings);
                             else
@@ -292,14 +300,14 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleCancel(final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleCancel(MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
-                final Mono<Message> sendMsg = Messages.sendMessage(Messages.getMessage("Creator.Announcement.Cancel.Success", settings), event);
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Message> sendMsg = Messages.sendMessage(Messages.getMessage("Creator.Announcement.Cancel.Success", settings), event);
 
                 AnnouncementCreator.getCreator().terminate(settings.getGuildID());
 
@@ -310,13 +318,13 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleDelete(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleDelete(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return Mono.when(deleteUserMessage, deleteCreatorMessage)
                     .then(AnnouncementMessageFormatter.getFormatAnnouncementEmbed(a, settings))
@@ -347,13 +355,13 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleView(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleView(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return Mono.when(deleteUserMessage, deleteCreatorMessage)
                     .then(AnnouncementMessageFormatter.getFormatAnnouncementEmbed(a, settings))
@@ -361,17 +369,17 @@ public class AnnouncementCommand implements Command {
                     .doOnNext(a::setCreatorMessage);
             } else {
                 if (args.length == 2) {
-                    final UUID id;
+                    UUID id;
                     try {
                         id = UUID.fromString(args[1]);
-                    } catch (final IllegalArgumentException e) {
+                    } catch (IllegalArgumentException e) {
                         return Messages.sendMessage(Messages.getMessage("Creator.Announcement.CannotFind.Announcement", settings), event);
                     }
 
                     return DatabaseManager.getAnnouncement(id, settings.getGuildID()).flatMap(a -> {
-                        final Mono<String> subNamesMono = event.getGuild()
+                        Mono<String> subNamesMono = event.getGuild()
                             .flatMap(g -> AnnouncementMessageFormatter.getSubscriberNames(a, g));
-                        final Mono<Consumer<EmbedCreateSpec>> emMono = AnnouncementMessageFormatter
+                        Mono<Consumer<EmbedCreateSpec>> emMono = AnnouncementMessageFormatter
                             .getFormatAnnouncementEmbed(a, settings);
 
                         return Mono.zip(subNamesMono, emMono)
@@ -386,13 +394,13 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleSubscribeRewriteArgsOne(final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleSubscribeRewriteArgsOne(MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return event.getMessage().getAuthorAsMember()
                     .flatMap(user -> {
@@ -420,15 +428,15 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleSubscribeRewriteArgsTwo(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleSubscribeRewriteArgsTwo(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
-            final String value = args[1];
+            String value = args[1];
             if (value.length() <= 32) {
                 if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                    final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                    Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                    final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                    final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                    Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                    Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                     if ("everyone".equalsIgnoreCase(value) || "here".equalsIgnoreCase(value)) {
                         if (!a.getSubscriberRoleIds().contains(value.toLowerCase().trim())) {
@@ -519,46 +527,46 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleSubscribeRewriteArgsThree(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleSubscribeRewriteArgsThree(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return event.getGuild().flatMap(guild -> {
             //First we check if the first arg is an announcement ID, because we don't want to stop people from subbing,
             //while a staff member is creating an announcement.
             if (args[1].length() > 32) {
                 return DatabaseManager.getAnnouncement(UUID.fromString(args[1]), settings.getGuildID()).flatMap(a -> {
                     //We have the announcement, now lets handle subscribing all of those users/roles...
-                    final List<String> toLookFor = Arrays.asList(args).subList(2, args.length);
+                    List<String> toLookFor = Arrays.asList(args).subList(2, args.length);
 
-                    final Mono<List<Member>> membersMono = Flux.fromIterable(toLookFor)
+                    Mono<List<Member>> membersMono = Flux.fromIterable(toLookFor)
                         .flatMap(str -> UserUtils.getUser(str, guild))
                         .collectList()
                         .defaultIfEmpty(new ArrayList<>()); //So the zip doesn't fail..
 
-                    final Mono<List<Role>> rolesMono = Flux.fromIterable(toLookFor)
+                    Mono<List<Role>> rolesMono = Flux.fromIterable(toLookFor)
                         .flatMap(str -> RoleUtils.getRole(str, guild))
                         .collectList()
                         .defaultIfEmpty(new ArrayList<>()); //So the zip doesn't fail..
 
                     return Mono.zip(membersMono, rolesMono).flatMap(TupleUtils.function((members, roles) -> {
-                        final List<String> subbedMembers = new ArrayList<>();
-                        final List<String> subbedRoles = new ArrayList<>();
+                        List<String> subbedMembers = new ArrayList<>();
+                        List<String> subbedRoles = new ArrayList<>();
 
-                        for (final Member m : members) {
+                        for (Member m : members) {
                             if (!a.getSubscriberUserIds().contains(m.getId().asString())) {
                                 a.getSubscriberUserIds().add(m.getId().asString());
                                 subbedMembers.add(m.getDisplayName());
                             }
                         }
 
-                        for (final Role r : roles) {
+                        for (Role r : roles) {
                             if (!a.getSubscriberRoleIds().contains(r.getId().asString())) {
                                 a.getSubscriberRoleIds().add(r.getId().asString());
                                 subbedRoles.add(r.getName());
                             }
                         }
 
-                        final String subMemString = subbedMembers.toString().replace("[", "").replace("]", "");
-                        final String subRoleString = subbedRoles.toString().replace("[", "").replace("]", "");
-                        final Consumer<EmbedCreateSpec> embed = spec -> {
+                        String subMemString = subbedMembers.toString().replace("[", "").replace("]", "");
+                        String subRoleString = subbedRoles.toString().replace("[", "").replace("]", "");
+                        Consumer<EmbedCreateSpec> embed = spec -> {
                             spec.setAuthor("DisCal", GlobalConst.discalSite, GlobalConst.iconUrl);
                             spec.setColor(GlobalConst.discalColor);
 
@@ -584,45 +592,45 @@ public class AnnouncementCommand implements Command {
                         Messages.sendMessage(Messages.getMessage("Creator.Announcement.CannotFind.Announcement",
                             settings), event));
             } else if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 //Okay, now lets just go about subscribing all of the users/roles...
-                final List<String> toLookFor = Arrays.asList(args).subList(1, args.length);
+                List<String> toLookFor = Arrays.asList(args).subList(1, args.length);
 
-                final Mono<List<Member>> membersMono = Flux.fromIterable(toLookFor)
+                Mono<List<Member>> membersMono = Flux.fromIterable(toLookFor)
                     .flatMap(str -> UserUtils.getUser(str, guild))
                     .collectList()
                     .defaultIfEmpty(new ArrayList<>()); //So the zip doesn't fail..
 
-                final Mono<List<Role>> rolesMono = Flux.fromIterable(toLookFor)
+                Mono<List<Role>> rolesMono = Flux.fromIterable(toLookFor)
                     .flatMap(str -> RoleUtils.getRole(str, guild))
                     .collectList()
                     .defaultIfEmpty(new ArrayList<>()); //So the zip doesn't fail..
 
                 return Mono.zip(membersMono, rolesMono).flatMap(TupleUtils.function((members, roles) -> {
-                    final List<String> subbedMembers = new ArrayList<>();
-                    final List<String> subbedRoles = new ArrayList<>();
+                    List<String> subbedMembers = new ArrayList<>();
+                    List<String> subbedRoles = new ArrayList<>();
 
-                    for (final Member m : members) {
+                    for (Member m : members) {
                         if (!a.getSubscriberUserIds().contains(m.getId().asString())) {
                             a.getSubscriberUserIds().add(m.getId().asString());
                             subbedMembers.add(m.getDisplayName());
                         }
                     }
 
-                    for (final Role r : roles) {
+                    for (Role r : roles) {
                         if (!a.getSubscriberRoleIds().contains(r.getId().asString())) {
                             a.getSubscriberRoleIds().add(r.getId().asString());
                             subbedRoles.add(r.getName());
                         }
                     }
 
-                    final String subMemString = subbedMembers.toString().replace("[", "").replace("]", "");
-                    final String subRoleString = subbedRoles.toString().replace("[", "").replace("]", "");
-                    final Consumer<EmbedCreateSpec> embed = spec -> {
+                    String subMemString = subbedMembers.toString().replace("[", "").replace("]", "");
+                    String subRoleString = subbedRoles.toString().replace("[", "").replace("]", "");
+                    Consumer<EmbedCreateSpec> embed = spec -> {
                         spec.setAuthor("DisCal", GlobalConst.discalSite, GlobalConst.iconUrl);
                         spec.setColor(GlobalConst.discalColor);
 
@@ -649,7 +657,7 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleSubscribeRewrite(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleSubscribeRewrite(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (args.length == 1)
                 return this.moduleSubscribeRewriteArgsOne(event, settings);
@@ -660,13 +668,13 @@ public class AnnouncementCommand implements Command {
         });
     }
 
-    private Mono<Void> moduleUnsubscribeRewriteArgsOne(final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleUnsubscribeRewriteArgsOne(MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return event.getMessage().getAuthorAsMember()
                     .flatMap(user -> {
@@ -694,15 +702,15 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleUnsubscribeRewriteArgsTwo(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleUnsubscribeRewriteArgsTwo(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
-            final String value = args[1];
+            String value = args[1];
             if (value.length() <= 32) {
                 if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                    final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                    Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                    final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                    final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                    Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                    Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                     if ("everyone".equalsIgnoreCase(value) || "here".equalsIgnoreCase(value)) {
                         if (a.getSubscriberRoleIds().contains(value.toLowerCase().trim())) {
@@ -791,46 +799,46 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleUnsubscribeRewriteArgsThree(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleUnsubscribeRewriteArgsThree(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return event.getGuild().flatMap(guild -> {
             //First we check if the first arg is an announcement ID, because we don't want to stop people from unsubbing,
             //while a staff member is creating an announcement.
             if (args[1].length() > 32) {
                 return DatabaseManager.getAnnouncement(UUID.fromString(args[1]), settings.getGuildID()).flatMap(a -> {
                     //We have the announcement, now lets handle subscribing all of those users/roles...
-                    final List<String> toLookFor = Arrays.asList(args).subList(2, args.length);
+                    List<String> toLookFor = Arrays.asList(args).subList(2, args.length);
 
-                    final Mono<List<Member>> membersMono = Flux.fromIterable(toLookFor)
+                    Mono<List<Member>> membersMono = Flux.fromIterable(toLookFor)
                         .flatMap(str -> UserUtils.getUser(str, guild))
                         .collectList()
                         .defaultIfEmpty(new ArrayList<>()); //So the zip doesn't fail..
 
-                    final Mono<List<Role>> rolesMono = Flux.fromIterable(toLookFor)
+                    Mono<List<Role>> rolesMono = Flux.fromIterable(toLookFor)
                         .flatMap(str -> RoleUtils.getRole(str, guild))
                         .collectList()
                         .defaultIfEmpty(new ArrayList<>()); //So the zip doesn't fail..
 
                     return Mono.zip(membersMono, rolesMono).flatMap(TupleUtils.function((members, roles) -> {
-                        final List<String> subbedMembers = new ArrayList<>();
-                        final List<String> subbedRoles = new ArrayList<>();
+                        List<String> subbedMembers = new ArrayList<>();
+                        List<String> subbedRoles = new ArrayList<>();
 
-                        for (final Member m : members) {
+                        for (Member m : members) {
                             if (a.getSubscriberUserIds().contains(m.getId().asString())) {
                                 a.getSubscriberUserIds().remove(m.getId().asString());
                                 subbedMembers.add(m.getDisplayName());
                             }
                         }
 
-                        for (final Role r : roles) {
+                        for (Role r : roles) {
                             if (a.getSubscriberRoleIds().contains(r.getId().asString())) {
                                 a.getSubscriberRoleIds().remove(r.getId().asString());
                                 subbedRoles.add(r.getName());
                             }
                         }
 
-                        final String subMemString = subbedMembers.toString().replace("[", "").replace("]", "");
-                        final String subRoleString = subbedRoles.toString().replace("[", "").replace("]", "");
-                        final Consumer<EmbedCreateSpec> embed = spec -> {
+                        String subMemString = subbedMembers.toString().replace("[", "").replace("]", "");
+                        String subRoleString = subbedRoles.toString().replace("[", "").replace("]", "");
+                        Consumer<EmbedCreateSpec> embed = spec -> {
                             spec.setAuthor("DisCal", GlobalConst.discalSite, GlobalConst.iconUrl);
                             spec.setColor(GlobalConst.discalColor);
 
@@ -856,45 +864,45 @@ public class AnnouncementCommand implements Command {
                         Messages.sendMessage(Messages.getMessage("Creator.Announcement.CannotFind.Announcement",
                             settings), event));
             } else if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 //Okay, now lets just go about subscribing all of the users/roles...
-                final List<String> toLookFor = Arrays.asList(args).subList(1, args.length);
+                List<String> toLookFor = Arrays.asList(args).subList(1, args.length);
 
-                final Mono<List<Member>> membersMono = Flux.fromIterable(toLookFor)
+                Mono<List<Member>> membersMono = Flux.fromIterable(toLookFor)
                     .flatMap(str -> UserUtils.getUser(str, guild))
                     .collectList()
                     .defaultIfEmpty(new ArrayList<>()); //So the zip doesn't fail..
 
-                final Mono<List<Role>> rolesMono = Flux.fromIterable(toLookFor)
+                Mono<List<Role>> rolesMono = Flux.fromIterable(toLookFor)
                     .flatMap(str -> RoleUtils.getRole(str, guild))
                     .collectList()
                     .defaultIfEmpty(new ArrayList<>()); //So the zip doesn't fail..
 
                 return Mono.zip(membersMono, rolesMono).flatMap(TupleUtils.function((members, roles) -> {
-                    final List<String> subbedMembers = new ArrayList<>();
-                    final List<String> subbedRoles = new ArrayList<>();
+                    List<String> subbedMembers = new ArrayList<>();
+                    List<String> subbedRoles = new ArrayList<>();
 
-                    for (final Member m : members) {
+                    for (Member m : members) {
                         if (a.getSubscriberUserIds().contains(m.getId().asString())) {
                             a.getSubscriberUserIds().remove(m.getId().asString());
                             subbedMembers.add(m.getDisplayName());
                         }
                     }
 
-                    for (final Role r : roles) {
+                    for (Role r : roles) {
                         if (a.getSubscriberRoleIds().contains(r.getId().asString())) {
                             a.getSubscriberRoleIds().remove(r.getId().asString());
                             subbedRoles.add(r.getName());
                         }
                     }
 
-                    final String subMemString = subbedMembers.toString().replace("[", "").replace("]", "");
-                    final String subRoleString = subbedRoles.toString().replace("[", "").replace("]", "");
-                    final Consumer<EmbedCreateSpec> embed = spec -> {
+                    String subMemString = subbedMembers.toString().replace("[", "").replace("]", "");
+                    String subRoleString = subbedRoles.toString().replace("[", "").replace("]", "");
+                    Consumer<EmbedCreateSpec> embed = spec -> {
                         spec.setAuthor("DisCal", GlobalConst.discalSite, GlobalConst.iconUrl);
                         spec.setColor(GlobalConst.discalColor);
 
@@ -921,7 +929,7 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleUnsubscribeRewrite(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleUnsubscribeRewrite(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (args.length == 1)
                 return this.moduleUnsubscribeRewriteArgsOne(event, settings);
@@ -932,21 +940,21 @@ public class AnnouncementCommand implements Command {
         });
     }
 
-    private Mono<Void> moduleType(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleType(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 if (args.length == 2) {
                     if (AnnouncementType.isValid(args[1])) {
-                        final AnnouncementType type = AnnouncementType.fromValue(args[1]);
+                        AnnouncementType type = AnnouncementType.fromValue(args[1]);
                         a.setAnnouncementType(type);
 
                         //Get the correct message to send depending on the type...
-                        final String msg;
+                        String msg;
                         switch (type) {
                             case SPECIFIC:
                                 msg = Messages.getMessage("Creator.Announcement.Type.Success.Specific", settings);
@@ -991,19 +999,19 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleHours(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleHours(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 if (args.length == 2) {
-                    final int hours;
+                    int hours;
                     try {
                         hours = Math.abs(Integer.parseInt(args[1]));
-                    } catch (final NumberFormatException ignore) {
+                    } catch (NumberFormatException ignore) {
                         return Mono.when(deleteUserMessage, deleteCreatorMessage)
                             .then(AnnouncementMessageFormatter.getFormatAnnouncementEmbed(a, settings))
                             .flatMap(em -> Messages.sendMessage(
@@ -1030,19 +1038,19 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleMinutes(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleMinutes(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 if (args.length == 2) {
-                    final int minutes;
+                    int minutes;
                     try {
                         minutes = Math.abs(Integer.parseInt(args[1]));
-                    } catch (final NumberFormatException ignore) {
+                    } catch (NumberFormatException ignore) {
                         return Mono.when(deleteUserMessage, deleteCreatorMessage)
                             .then(AnnouncementMessageFormatter.getFormatAnnouncementEmbed(a, settings))
                             .flatMap(em -> Messages.sendMessage(
@@ -1069,13 +1077,13 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleList(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleList(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return Mono.when(deleteUserMessage, deleteCreatorMessage)
                     .then(AnnouncementMessageFormatter.getFormatAnnouncementEmbed(a, settings))
@@ -1093,16 +1101,16 @@ public class AnnouncementCommand implements Command {
                                 .then()));
                 } else {
                     //List specific amount of announcements...
-                    final int amount;
+                    int amount;
                     try {
                         amount = Integer.parseInt(args[1]);
-                    } catch (final NumberFormatException ignore) {
+                    } catch (NumberFormatException ignore) {
                         return Messages.sendMessage(Messages.getMessage("Creator.Announcement.List.NotInt", settings),
                             event);
                     }
 
                     return DatabaseManager.getAnnouncements(settings.getGuildID()).flatMap(allAnnouncements -> {
-                        final List<Announcement> toPost; //We only post the amount listed...
+                        List<Announcement> toPost; //We only post the amount listed...
                         if (allAnnouncements.size() > amount)
                             toPost = allAnnouncements.subList(0, amount);
                         else
@@ -1122,13 +1130,13 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleEvent(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleEvent(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 if (args.length == 2) {
                     if (a.getAnnouncementType().equals(AnnouncementType.SPECIFIC)) {
@@ -1195,13 +1203,13 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleInfo(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleInfo(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 if (args.length >= 2) {
                     a.setInfo(GeneralUtils.getContent(args, 1));
@@ -1224,13 +1232,13 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleEnable(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleEnable(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return Mono.when(deleteUserMessage, deleteCreatorMessage)
                     .then(AnnouncementMessageFormatter.getFormatAnnouncementEmbed(a, settings))
@@ -1240,8 +1248,8 @@ public class AnnouncementCommand implements Command {
             } else if (args.length == 2) {
                 return AnnouncementUtils.announcementExists(args[1], settings.getGuildID()).flatMap(exists -> {
                     if (exists) {
-                        final UUID id = UUID.fromString(args[1]);
-                        final AtomicBoolean en = new AtomicBoolean(false); //This has got to be tested...
+                        UUID id = UUID.fromString(args[1]);
+                        AtomicBoolean en = new AtomicBoolean(false); //This has got to be tested...
                         return DatabaseManager.getAnnouncement(id, settings.getGuildID())
                             .doOnNext(a -> a.setEnabled(!a.isEnabled()))
                             .doOnNext(a -> en.set(a.isEnabled()))
@@ -1259,13 +1267,13 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleInfoOnly(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleInfoOnly(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return Mono.when(deleteUserMessage, deleteCreatorMessage)
                     .then(AnnouncementMessageFormatter.getFormatAnnouncementEmbed(a, settings))
@@ -1275,8 +1283,8 @@ public class AnnouncementCommand implements Command {
             } else if (args.length == 2) {
                 return AnnouncementUtils.announcementExists(args[1], settings.getGuildID()).flatMap(exists -> {
                     if (exists) {
-                        final UUID id = UUID.fromString(args[1]);
-                        final AtomicBoolean io = new AtomicBoolean(false); //This has got to be tested...
+                        UUID id = UUID.fromString(args[1]);
+                        AtomicBoolean io = new AtomicBoolean(false); //This has got to be tested...
                         return DatabaseManager.getAnnouncement(id, settings.getGuildID())
                             .doOnNext(a -> a.setInfoOnly(!a.isInfoOnly()))
                             .doOnNext(a -> io.set(a.isInfoOnly()))
@@ -1294,19 +1302,19 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> modulePublish(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> modulePublish(String[] args, MessageCreateEvent event, GuildSettings settings) {
         //TODO: Add code
 
         return Mono.empty();
     }
 
-    private Mono<Void> moduleChannel(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleChannel(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 if (args.length == 2) {
                     return ChannelUtils.channelExists(args[1], event).flatMap(exists -> {
@@ -1339,13 +1347,13 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleColor(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleColor(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 if (a.getAnnouncementType().equals(AnnouncementType.COLOR)) {
                     if (args.length == 2) {
@@ -1385,7 +1393,7 @@ public class AnnouncementCommand implements Command {
         }).then();
     }
 
-    private Mono<Void> moduleCopy(final String[] args, final MessageCreateEvent event, final GuildSettings settings) {
+    private Mono<Void> moduleCopy(String[] args, MessageCreateEvent event, GuildSettings settings) {
         return Mono.defer(() -> {
             if (!AnnouncementCreator.getCreator().hasAnnouncement(settings.getGuildID())) {
                 if (args.length == 2) {
@@ -1404,10 +1412,10 @@ public class AnnouncementCommand implements Command {
                     return Messages.sendMessage(Messages.getMessage("Creator.Announcement.Copy.Specify", settings), event);
                 }
             } else {
-                final Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
+                Announcement a = AnnouncementCreator.getCreator().getAnnouncement(settings.getGuildID());
 
-                final Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
-                final Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
+                Mono<Void> deleteUserMessage = Messages.deleteMessage(event);
+                Mono<Void> deleteCreatorMessage = Messages.deleteMessage(a.getCreatorMessage());
 
                 return Mono.when(deleteUserMessage, deleteCreatorMessage)
                     .then(AnnouncementMessageFormatter.getFormatAnnouncementEmbed(a, settings))

--- a/core/src/main/java/org/dreamexposure/discal/core/database/DatabaseManager.java
+++ b/core/src/main/java/org/dreamexposure/discal/core/database/DatabaseManager.java
@@ -309,7 +309,7 @@ public class DatabaseManager {
                         + " SET SUBSCRIBERS_ROLE = ?, SUBSCRIBERS_USER = ?, CHANNEL_ID = ?,"
                         + " ANNOUNCEMENT_TYPE = ?, MODIFIER = ?, EVENT_ID = ?, EVENT_COLOR = ?, "
                         + " HOURS_BEFORE = ?, MINUTES_BEFORE = ?,"
-                        + " INFO = ?, ENABLED = ?, INFO_ONLY = ?"
+                        + " INFO = ?, ENABLED = ?, INFO_ONLY = ?, PUBLISH = ?"
                         + " WHERE ANNOUNCEMENT_ID = ?";
 
                     return connect(master, c -> Mono.from(c.createStatement(update)
@@ -325,7 +325,8 @@ public class DatabaseManager {
                         .bind(9, announcement.getInfo())
                         .bind(10, announcement.isEnabled())
                         .bind(11, announcement.isInfoOnly())
-                        .bind(12, announcement.getAnnouncementId().toString())
+                        .bind(12, announcement.isPublishable())
+                        .bind(13, announcement.getAnnouncementId().toString())
                         .execute())
                     ).flatMap(res -> Mono.from(res.getRowsUpdated()))
                         .thenReturn(true);
@@ -333,8 +334,8 @@ public class DatabaseManager {
                     final String insertCommand = "INSERT INTO " + table +
                         "(ANNOUNCEMENT_ID, GUILD_ID, SUBSCRIBERS_ROLE, SUBSCRIBERS_USER, " +
                         "CHANNEL_ID, ANNOUNCEMENT_TYPE, MODIFIER, EVENT_ID, EVENT_COLOR, " +
-                        "HOURS_BEFORE, MINUTES_BEFORE, INFO, ENABLED, INFO_ONLY)" +
-                        " VALUE (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                        "HOURS_BEFORE, MINUTES_BEFORE, INFO, ENABLED, INFO_ONLY, PUBLISH)" +
+                        " VALUE (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
                     return connect(master, c -> Mono.from(c.createStatement(insertCommand)
                         .bind(0, announcement.getAnnouncementId().toString())
@@ -351,6 +352,7 @@ public class DatabaseManager {
                         .bind(11, announcement.getInfo())
                         .bind(12, announcement.isEnabled())
                         .bind(13, announcement.isInfoOnly())
+                        .bind(14, announcement.isPublishable())
                         .execute())
                     ).flatMap(res -> Mono.from(res.getRowsUpdated()))
                         .thenReturn(true);
@@ -734,6 +736,7 @@ public class DatabaseManager {
             a.setInfo(row.get("INFO", String.class));
             a.setEnabled(row.get("ENABLED", Boolean.class));
             a.setInfoOnly(row.get("INFO_ONLY", Boolean.class));
+            a.setPublishable(row.get("PUBLISH", Boolean.class));
 
             return a;
         }))
@@ -772,6 +775,7 @@ public class DatabaseManager {
             a.setInfo(row.get("INFO", String.class));
             a.setEnabled(row.get("ENABLED", Boolean.class));
             a.setInfoOnly(row.get("INFO_ONLY", Boolean.class));
+            a.setPublishable(row.get("PUBLISH", Boolean.class));
 
             return a;
         }))
@@ -811,6 +815,7 @@ public class DatabaseManager {
             a.setInfo(row.get("INFO", String.class));
             a.setEnabled(row.get("ENABLED", Boolean.class));
             a.setInfoOnly(row.get("INFO_ONLY", Boolean.class));
+            a.setPublishable(row.get("PUBLISH", Boolean.class));
 
             return a;
         }))
@@ -852,6 +857,7 @@ public class DatabaseManager {
             a.setInfo(row.get("INFO", String.class));
             a.setEnabled(row.get("ENABLED", Boolean.class));
             a.setInfoOnly(row.get("INFO_ONLY", Boolean.class));
+            a.setPublishable(row.get("PUBLISH", Boolean.class));
 
             return a;
         }))
@@ -891,6 +897,7 @@ public class DatabaseManager {
             a.setInfo(row.get("INFO", String.class));
             a.setEnabled(row.get("ENABLED", Boolean.class));
             a.setInfoOnly(row.get("INFO_ONLY", Boolean.class));
+            a.setPublishable(row.get("PUBLISH", Boolean.class));
 
             return a;
         }))
@@ -932,6 +939,7 @@ public class DatabaseManager {
             a.setInfo(row.get("INFO", String.class));
             a.setEnabled(row.get("ENABLED", Boolean.class));
             a.setInfoOnly(row.get("INFO_ONLY", Boolean.class));
+            a.setPublishable(row.get("PUBLISH", Boolean.class));
 
             return a;
         }))
@@ -972,6 +980,7 @@ public class DatabaseManager {
             a.setInfo(row.get("INFO", String.class));
             a.setEnabled(row.get("ENABLED", Boolean.class));
             a.setInfoOnly(row.get("INFO_ONLY", Boolean.class));
+            a.setPublishable(row.get("PUBLISH", Boolean.class));
 
             return a;
         }))

--- a/core/src/main/java/org/dreamexposure/discal/core/object/announcement/Announcement.java
+++ b/core/src/main/java/org/dreamexposure/discal/core/object/announcement/Announcement.java
@@ -1,5 +1,7 @@
 package org.dreamexposure.discal.core.object.announcement;
 
+import discord4j.common.util.Snowflake;
+import discord4j.core.object.entity.Message;
 import org.dreamexposure.discal.core.enums.announcement.AnnouncementModifier;
 import org.dreamexposure.discal.core.enums.announcement.AnnouncementType;
 import org.dreamexposure.discal.core.enums.event.EventColor;
@@ -9,9 +11,6 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.UUID;
-
-import discord4j.common.util.Snowflake;
-import discord4j.core.object.entity.Message;
 
 /**
  * Created by Nova Fox on 11/10/17.
@@ -37,6 +36,7 @@ public class Announcement {
 
     private boolean enabled;
     private boolean infoOnly;
+    private boolean publish;
 
     //Stuff for creator/editor wizards.
     private Message creatorMessage;
@@ -285,6 +285,10 @@ public class Announcement {
         return this.infoOnly;
     }
 
+    public boolean isPublishable() {
+        return this.publish;
+    }
+
     public Message getCreatorMessage() {
         return this.creatorMessage;
     }
@@ -364,6 +368,10 @@ public class Announcement {
         this.infoOnly = _infoOnly;
     }
 
+    public void setPublishable(final boolean publish) {
+        this.publish = publish;
+    }
+
     /**
      * Sets the subscribers of the announcement from a String.
      *
@@ -437,6 +445,7 @@ public class Announcement {
         data.put("info", this.info);
         data.put("enabled", this.enabled);
         data.put("info_only", this.infoOnly);
+        data.put("publish", this.publish);
 
         return data;
     }
@@ -465,6 +474,7 @@ public class Announcement {
         this.info = data.getString("info");
         this.enabled = data.getBoolean("enabled");
         this.infoOnly = data.getBoolean("info_only");
+        this.publish = data.getBoolean("publish");
 
         return this;
     }

--- a/core/src/main/resources/db/migration/V9__Publishable_Announcements.sql
+++ b/core/src/main/resources/db/migration/V9__Publishable_Announcements.sql
@@ -1,5 +1,5 @@
 # noinspection SqlResolveForFile
 
 ALTER TABLE `${prefix}announcements`
-    ADD COLUMN PUBLISH BIT(1) NOT NULL DEFAULT '0'
+    ADD COLUMN PUBLISH BIT(1) NOT NULL DEFAULT 0
         AFTER INFO_ONLY;

--- a/core/src/main/resources/db/migration/V9__Publishable_Announcements.sql
+++ b/core/src/main/resources/db/migration/V9__Publishable_Announcements.sql
@@ -1,0 +1,5 @@
+# noinspection SqlResolveForFile
+
+ALTER TABLE `${prefix}announcements`
+    ADD COLUMN PUBLISH BIT(1) NOT NULL DEFAULT '0'
+        AFTER INFO_ONLY;

--- a/server/src/main/java/org/dreamexposure/discal/server/DisCalServer.java
+++ b/server/src/main/java/org/dreamexposure/discal/server/DisCalServer.java
@@ -19,7 +19,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
 import org.springframework.boot.system.ApplicationPid;
 
-import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
@@ -37,7 +36,7 @@ public class DisCalServer {
     public static void main(final String[] args) throws IOException {
         //Get settings
         final Properties p = new Properties();
-        p.load(new FileReader(new File("settings.properties")));
+        p.load(new FileReader("settings.properties"));
         BotSettings.init(p);
 
         if (args.length > 1 && "-forceNewAuth".equalsIgnoreCase(args[0])) {

--- a/server/src/main/java/org/dreamexposure/discal/server/DisCalServer.java
+++ b/server/src/main/java/org/dreamexposure/discal/server/DisCalServer.java
@@ -133,6 +133,7 @@ public class DisCalServer {
             LogFeed.log(LogObject.forDebug("Migrations Successful", sm + " migrations applied!"));
         } catch (final Exception e) {
             LogFeed.log(LogObject.forException("Migrations failure", e, DisCalServer.class));
+            e.printStackTrace();
             System.exit(2);
         }
     }


### PR DESCRIPTION
Add ability to "publish" or crosspost announcements when they are posted in news channels. 

This is a patron only feature, since it is not needed for functionality, but can be nice for larger communities or when having multiple servers. 
For example, if there is an esports league posting announcements for games, teams can subscribe to a news channel that the announcements are posted in so their players will see the event announcements in the team server.

`!a publish` while editing or creating an announcement will toggle the setting and it is visible in the editor embed. 

Will also fail silently if publishing is enabled on the announcement but the channel it is posted in is not a news channel.