### PR TITLE
Fix external calendar all day event editing

### DIFF
--- a/client/src/main/java/org/dreamexposure/discal/client/event/EventCreator.java
+++ b/client/src/main/java/org/dreamexposure/discal/client/event/EventCreator.java
@@ -90,9 +90,8 @@ public class EventCreator {
         if (!this.hasPreEvent(settings.getGuildID())) {
             return DatabaseManager.getCalendar(settings.getGuildID(), 1) //TODO: handle multiple calendars
                 .flatMap(calData -> EventWrapper.getEvent(calData, eventId)
-                    .flatMap(toCopy -> {
-                        final PreEvent event = new PreEvent(settings.getGuildID(), toCopy, calData);
-
+                    .flatMap(toCopy -> PreEvent.copy(settings.getGuildID(), toCopy, calData))
+                    .flatMap(event -> {
                         this.events.add(event);
 
                         return CalendarWrapper.getCalendar(calData)
@@ -112,8 +111,8 @@ public class EventCreator {
         if (!this.hasPreEvent(settings.getGuildID())) {
             return DatabaseManager.getCalendar(settings.getGuildID(), 1) //TODO: handle multiple calendars
                 .flatMap(calData -> EventWrapper.getEvent(calData, eventId)
-                    .flatMap(toEdit -> {
-                        final PreEvent event = new PreEvent(settings.getGuildID(), toEdit, calData);
+                    .flatMap(toEdit -> PreEvent.copy(settings.getGuildID(), toEdit, calData))
+                    .flatMap(event -> {
                         event.setEditing(true);
 
                         this.events.add(event);

--- a/core/src/main/java/org/dreamexposure/discal/core/utils/TimeUtils.java
+++ b/core/src/main/java/org/dreamexposure/discal/core/utils/TimeUtils.java
@@ -67,7 +67,12 @@ public class TimeUtils {
                 final SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd-HH:mm:ss");
                 sdf.setTimeZone(timezone);
                 final Date endDate = sdf.parse(endRaw);
-                final Date startDate = new Date(event.getStartDateTime().getDateTime().getValue());
+
+                final Date startDate;
+                if (event.getStartDateTime().getDateTime() != null)
+                    startDate = new Date(event.getStartDateTime().getDateTime().getValue());
+                else
+                    startDate = new Date(event.getStartDateTime().getDate().getValue());
 
                 return endDate.before(startDate);
             } catch (final ParseException e) {
@@ -77,13 +82,20 @@ public class TimeUtils {
         return false;
     }
 
+    //TODO: For future Nova, test this. has already been deployed to dev shard
     public static boolean hasStartAfterEnd(final String startRaw, final TimeZone timezone, final PreEvent event) {
         if (event.getEndDateTime() != null) {
             try {
                 final SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd-HH:mm:ss");
                 sdf.setTimeZone(timezone);
                 final Date startDate = sdf.parse(startRaw);
-                final Date endDate = new Date(event.getEndDateTime().getDateTime().getValue());
+
+                Date endDate;
+                if (event.getEndDateTime().getDateTime() != null)
+                    endDate = new Date(event.getEndDateTime().getDateTime().getValue());
+                else
+                    endDate = new Date(event.getEndDateTime().getDate().getValue());
+
 
                 return startDate.after(endDate);
             } catch (final ParseException e) {

--- a/core/src/main/java/org/dreamexposure/discal/core/utils/TimeUtils.java
+++ b/core/src/main/java/org/dreamexposure/discal/core/utils/TimeUtils.java
@@ -1,5 +1,6 @@
 package org.dreamexposure.discal.core.utils;
 
+import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.model.Event;
 
 import org.dreamexposure.discal.core.database.DatabaseManager;
@@ -10,6 +11,9 @@ import org.dreamexposure.discal.core.wrapper.google.EventWrapper;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -82,7 +86,6 @@ public class TimeUtils {
         return false;
     }
 
-    //TODO: For future Nova, test this. has already been deployed to dev shard
     public static boolean hasStartAfterEnd(final String startRaw, final TimeZone timezone, final PreEvent event) {
         if (event.getEndDateTime() != null) {
             try {
@@ -103,5 +106,18 @@ public class TimeUtils {
             }
         }
         return false;
+    }
+
+    public static DateTime doTimeShiftBullshit(DateTime original, ZoneId tz) {
+        return new DateTime(Instant.ofEpochMilli(original.getValue())
+            .plus(1, ChronoUnit.DAYS)
+            .atZone(tz)
+            .truncatedTo(ChronoUnit.DAYS)
+            .toLocalDate()
+            .atStartOfDay()
+            .atZone(tz)
+            .toInstant()
+            .toEpochMilli()
+        );
     }
 }

--- a/core/src/main/kotlin/org/dreamexposure/discal/core/object/event/PreEvent.kt
+++ b/core/src/main/kotlin/org/dreamexposure/discal/core/object/event/PreEvent.kt
@@ -40,7 +40,11 @@ data class PreEvent private constructor(
     constructor(guildId: Snowflake, calNumber: Int) : this(guildId, "N/a", calNumber)
 
     constructor(guildId: Snowflake, e: Event, calData: CalendarData) : this(guildId, e.id, calData.calendarNumber) {
-        this.color = EventColor.fromNameOrHexOrId(e.colorId)
+        try {
+            this.color = EventColor.fromNameOrHexOrId(e.colorId)
+        } catch (ignore: NullPointerException) {
+            this.color = EventColor.NONE
+        }
 
         if (e.recurrence != null && e.recurrence.isNotEmpty()) {
             this.recur = true
@@ -56,7 +60,7 @@ data class PreEvent private constructor(
 
         if (e.start.timeZone != null) this.timezone = e.start.timeZone
 
-        this.eventData = DatabaseManager.getEventData(this.guildId, e.id).block()!!
+        this.eventData = DatabaseManager.getEventData(this.guildId, e.id).block() ?: EventData(guildId, eventId)
     }
 
     //Functions


### PR DESCRIPTION
Previously, all day events created on an external calendar where unable to be edited due to dumb google API nonsense. This has now been fixed and external calendar all day events can be edited just like every other kind of event.

Resolves #44