### PR TITLE
Adds all day and multi-day event displays to `/displaycal`

### DIFF
--- a/client/src/main/kotlin/org/dreamexposure/discal/client/message/embed/CalendarEmbed.kt
+++ b/client/src/main/kotlin/org/dreamexposure/discal/client/message/embed/CalendarEmbed.kt
@@ -15,6 +15,7 @@ import reactor.core.publisher.Mono
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 object CalendarEmbed : EmbedMaker {
     fun link(guild: Guild, settings: GuildSettings, calNumber: Int, overview: Boolean): Mono<EmbedCreateSpec> {
@@ -62,10 +63,31 @@ object CalendarEmbed : EmbedMaker {
 
                 val content = StringBuilder().append("```\n")
                 sortedEvents.forEach {
-                    content.append(it.start.humanReadableTime(it.timezone, settings.timeFormat))
-                        .append(" - ")
-                        .append(it.end.humanReadableTime(it.timezone, settings.timeFormat))
-                        .append(" | ")
+                    // determine time length
+                    val timeDisplayLen = ("${it.start.humanReadableTime(it.timezone, settings.timeFormat)} -" +
+                        " ${it.end.humanReadableTime(it.timezone,settings.timeFormat)} ").length
+
+                    // Displaying time
+                   if (it.isAllDay()) {
+                       content.append(getCommonMsg("generic.time.allDay", settings).padCenter(timeDisplayLen))
+                           .append("| ")
+                   } else {
+                       // Add start text
+                       var str = if (it.start.isBefore(date.key.toInstant())) {
+                           "${getCommonMsg("generic.time.continued", settings)} - "
+                       } else {
+                           "${it.start.humanReadableTime(it.timezone, settings.timeFormat)} - "
+                       }
+                       // Add end text
+                       str += if (it.end.isAfter(date.key.toInstant().plus(1, ChronoUnit.DAYS))) {
+                           getCommonMsg("generic.time.continued", settings)
+                       } else {
+                           "${it.end.humanReadableTime(it.timezone, settings.timeFormat)} "
+                       }
+                       content.append(str.padCenter(timeDisplayLen))
+                           .append("| ")
+                   }
+                    // Display name or ID if not set
                     if (it.name.isNotBlank()) content.append(it.name)
                     else content.append(getMessage("calendar", "link.field.id", settings)).append(" ${it.eventId}")
                     content.append("\n")

--- a/client/src/main/kotlin/org/dreamexposure/discal/client/message/embed/CalendarEmbed.kt
+++ b/client/src/main/kotlin/org/dreamexposure/discal/client/message/embed/CalendarEmbed.kt
@@ -44,7 +44,7 @@ object CalendarEmbed : EmbedMaker {
     }
 
     fun overview(guild: Guild, settings: GuildSettings, calendar: Calendar, showUpdate: Boolean): Mono<EmbedCreateSpec> {
-        return calendar.getUpcomingEvents(15).collectList().map { it.groupByDate() }.map { events ->
+        return calendar.getUpcomingEvents(15).collectList().map { it.groupByDateMulti() }.map { events ->
             val builder = defaultBuilder(guild, settings)
 
             //Handle optional fields

--- a/core/src/main/kotlin/org/dreamexposure/discal/core/extensions/MutableList.kt
+++ b/core/src/main/kotlin/org/dreamexposure/discal/core/extensions/MutableList.kt
@@ -1,6 +1,8 @@
 package org.dreamexposure.discal.core.extensions
 
 import org.dreamexposure.discal.core.entities.Event
+import org.dreamexposure.discal.core.logger.LOGGER
+import java.time.Instant
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
@@ -27,9 +29,39 @@ fun MutableList<String>.setFromString(strList: String) {
 
 fun MutableList<Event>.groupByDate(): Map<ZonedDateTime, List<Event>> {
     return this.stream()
-            .collect(Collectors.groupingBy {
-                ZonedDateTime.ofInstant(it.start, it.timezone).truncatedTo(ChronoUnit.DAYS)
-                        .with(TemporalAdjusters.ofDateAdjuster { identity -> identity })
-            }).toSortedMap()
+        .collect(Collectors.groupingBy {
+            ZonedDateTime.ofInstant(it.start, it.timezone).truncatedTo(ChronoUnit.DAYS)
+                .with(TemporalAdjusters.ofDateAdjuster { identity -> identity })
+        }).toSortedMap()
 
+}
+
+fun MutableList<Event>.groupByDateMulti(): Map<ZonedDateTime, List<Event>> {
+    // Each of the days events start on, their ending is ignored
+    val dates = this.map {
+        ZonedDateTime.ofInstant(it.start, it.timezone).truncatedTo(ChronoUnit.DAYS)
+            .with(TemporalAdjusters.ofDateAdjuster { identity -> identity })
+    }.distinct().sorted()
+
+    val multi: MutableMap<ZonedDateTime, List<Event>> = mutableMapOf()
+
+    //FIXME: This is somehow duplicating too many events.
+    dates.forEach {
+        LOGGER.debug("Date: $it")
+
+        val range = LongRange(it.toEpochSecond(), it.plus(1, ChronoUnit.DAYS).toEpochSecond())
+        LOGGER.debug("Range: ${Instant.ofEpochSecond(range.first)} - ${Instant.ofEpochSecond(range.last)}")
+
+        val events: MutableList<Event> = mutableListOf()
+        this.forEach { event ->
+            if (range.contains(event.start.epochSecond) || range.contains(event.end.epochSecond)) {
+                LOGGER.debug("Event in range? Start: ${event.start} | End: ${event.end} | Name: ${event.name}")
+                events.add(event)
+            }
+        }
+        LOGGER.debug("events in this range: ${events.size}")
+        multi[it] = events
+    }
+
+    return multi.toSortedMap()
 }

--- a/core/src/main/kotlin/org/dreamexposure/discal/core/extensions/MutableList.kt
+++ b/core/src/main/kotlin/org/dreamexposure/discal/core/extensions/MutableList.kt
@@ -45,16 +45,17 @@ fun MutableList<Event>.groupByDateMulti(): Map<ZonedDateTime, List<Event>> {
 
     val multi: MutableMap<ZonedDateTime, List<Event>> = mutableMapOf()
 
-    //FIXME: This is somehow duplicating too many events.
     dates.forEach {
         LOGGER.debug("Date: $it")
 
-        val range = LongRange(it.toEpochSecond(), it.plus(1, ChronoUnit.DAYS).toEpochSecond())
+        val range = LongRange(it.toEpochSecond(), it.plusHours(23).plusMinutes(59).toEpochSecond())
         LOGGER.debug("Range: ${Instant.ofEpochSecond(range.first)} - ${Instant.ofEpochSecond(range.last)}")
 
         val events: MutableList<Event> = mutableListOf()
+
         this.forEach { event ->
-            if (range.contains(event.start.epochSecond) || range.contains(event.end.epochSecond)) {
+            // When we check event end, we bump it back a second in order to prevent weirdness.
+            if (range.contains(event.start.epochSecond) || range.contains(event.end.epochSecond - 1)) {
                 LOGGER.debug("Event in range? Start: ${event.start} | End: ${event.end} | Name: ${event.name}")
                 events.add(event)
             }

--- a/core/src/main/kotlin/org/dreamexposure/discal/core/extensions/String.kt
+++ b/core/src/main/kotlin/org/dreamexposure/discal/core/extensions/String.kt
@@ -29,3 +29,24 @@ fun String.isValidTimezone(): Boolean {
 }
 
 fun String.isValidImage(allowGif: Boolean) = ImageValidator.validate(this, allowGif)
+
+fun String.padCenter(length: Int, padChar: Char = ' '): String {
+    if (this.length >= length) return this
+
+    val chars: CharArray = this.toCharArray()
+    val delta = length - chars.size
+    val a = if (delta % 2 == 0) delta / 2 else delta / 2 + 1
+    val b = a + chars.size
+
+    val output = CharArray(length)
+    for (i in 0 until length) {
+        if (i < a) {
+            output[i] = padChar
+        } else if (i < b) {
+            output[i] = chars[i - a]
+        } else {
+            output[i] = padChar
+        }
+    }
+    return String(output)
+}

--- a/core/src/main/resources/i18n/common.properties
+++ b/core/src/main/resources/i18n/common.properties
@@ -2,6 +2,9 @@ bot.name=DisCal
 
 success.generic=Success
 
+generic.time.allDay=All day
+generic.time.continued=Cont.
+
 error.unknown=Sorry, an unknown error has occurred.
 
 error.notFound.event=No event with that ID was found. There may be a typo, or it may have been deleted.


### PR DESCRIPTION
This adds support to properly display all day and multi-day events on the displaycal embed.

The code could use some better optimization, but it gets the job done and will be good enough for now.

Closes #122 